### PR TITLE
Make some array copies explicit

### DIFF
--- a/src/crypto_stream/chacha/common/amd64/avx2/chacha.jinc
+++ b/src/crypto_stream/chacha/common/amd64/avx2/chacha.jinc
@@ -93,7 +93,7 @@ inline fn __init_x8_avx2(reg u64 key nonce, reg u32 counter) -> stack u256[16]
   // 13 { ... , n[31:0]    , n[31:0]    }
   // ...
   // 15 { ... , n[95:64]   , n[95:64]   }
-  st_ = st;
+  st_ = #copy(st);
   return st_;
 }
 
@@ -101,15 +101,15 @@ inline fn __init_x8_avx2(reg u64 key nonce, reg u32 counter) -> stack u256[16]
 inline fn __copy_state_x2_avx2(reg u256[4] st) -> reg u256[4]
 {
   reg u256[4] k;
-  k = st;
+  k = #copy(st);
   return k;
 }
 
 inline fn __copy_state_x4_avx2(reg u256[4] st) -> reg u256[4], reg u256[4]
 {
   reg u256[4] k1 k2;
-  k1 = st;
-  k2 = st;
+  k1 = #copy(st);
+  k2 = #copy(st);
   k2[3] +8u32= g_p2;
 
   // k2                         k1
@@ -123,7 +123,7 @@ inline fn __copy_state_x4_avx2(reg u256[4] st) -> reg u256[4], reg u256[4]
 inline fn __copy_state_x8_avx2(stack u256[16] st) -> reg u256[16]
 {
   reg u256[16] k;
-  k = st;
+  k = #copy(st);
   return k;
 }
 
@@ -459,7 +459,7 @@ inline fn __store_x8_last_avx2(reg u64 output plain, reg u32 len, reg u256[16] k
   reg   u256[8] k0_7 k8_15 i0_7;
 
   k0_7, s_k8_15 = __rotate_first_half_x8_avx2(k);
-  s_k0_7 = k0_7;
+  s_k0_7 = #copy(k0_7);
   k8_15 = __rotate_second_half_x8_avx2(s_k8_15);
   i0_7 = __interleave_avx2(s_k0_7, k8_15, i_0);
 


### PR DESCRIPTION
An array-to-array assignment used to be implicitly turned into a loop (at parsing time). Now (after https://github.com/jasmin-lang/jasmin/commit/f3f22711af4dc2365896dfb76650da662227497d) the copy can explicitly exist.